### PR TITLE
Fix typo that prevents script from working.

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ if "vmware" in settings and settings.get("vmware").get("enabled", True):
 if "hyper-v" in settings and settings.get("hyper-v").get("enabled", True):
     hypervisors.append("hyper-v")
     settings["hyper-v"]["enabled"] = True
-if hypervisor == []:
+if hypervisors == []:
     if Path("hypervisors.txt").is_file():
         # Client ID found in legacy file
         hypervisors = Path("hypervisors.txt").read_text()


### PR DESCRIPTION
So, in this script, if you try to start it now it will error out with this:

```
Traceback (most recent call last):
  File "main.py", line 52, in <module>
    if hypervisor == []:
NameError: name 'hypervisor' is not defined
```

This is because of a typo in main.py, where line 52 uses "hypervisor" instead of "hypervisors". This pull request just adds that "s" at the end to make the script work properly.